### PR TITLE
Pluggable agent runtime: support wksp alongside Claude Code

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libicu-dev \
     pkg-config \
     file \
+    # Declared by analyst personas (ast-grep/tree-sitter installed below).
+    # Missing binaries force tool_use retry loops that exhaust max_turns.
+    shellcheck \
+    binwalk \
+    libimage-exiftool-perl \
+    xxd \
+    cloc \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Node.js 20 ───────────────────────────────────────────────────────────────
@@ -131,6 +138,26 @@ RUN case "${TARGETARCH}" in \
 
 # ── Claude Code ──────────────────────────────────────────────────────────────
 RUN npm install -g @anthropic-ai/claude-code
+
+# ── tree-sitter CLI (declared by behaviorist + shadowcatcher personas) ──────
+RUN npm install -g tree-sitter-cli
+
+# ── ast-grep (declared by paranoid, behaviorist, pentester-*, shadowcatcher) ─
+ARG AST_GREP_VERSION=0.42.1
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        aarch64|arm64) target="aarch64-unknown-linux-gnu" ;; \
+        x86_64)        target="x86_64-unknown-linux-gnu"  ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL \
+        "https://github.com/ast-grep/ast-grep/releases/download/${AST_GREP_VERSION}/app-${target}.zip" \
+        -o /tmp/ast-grep.zip; \
+    unzip -j /tmp/ast-grep.zip "ast-grep" -d /usr/local/bin/; \
+    chmod +x /usr/local/bin/ast-grep; \
+    rm /tmp/ast-grep.zip; \
+    ast-grep --version
 
 # ── Non-root user ─────────────────────────────────────────────────────────────
 RUN userdel -r ubuntu 2>/dev/null || true \

--- a/src/thresher/agents/_runner.py
+++ b/src/thresher/agents/_runner.py
@@ -1,18 +1,23 @@
-"""Shared driver for running Claude Code agents in headless mode.
+"""Shared driver for running coding-agent CLIs in headless mode.
 
 Each Thresher agent (predep, analyst, adversarial, report-maker,
 synthesize) follows the same recipe:
 
 1. Write the prompt and (optional) stop-hook settings to tempfiles.
-2. Build a ``claude -p ... --model ... --allowedTools ... --output-format
-   stream-json --max-turns ...`` command.
+2. Build a CLI command that speaks Claude Code's stream-json shape.
 3. Merge ``config.ai_env()`` plus any agent-specific env vars into the
    subprocess environment.
-4. Run the subprocess via ``thresher.run.run`` and decode the stream-JSON.
+4. Run the subprocess via ``thresher.run.run`` and decode the stream.
 5. Pull the final result text and ``num_turns`` out of the stream.
 
-This module owns that recipe so the per-agent files only have to declare
-*what* they want, not *how* to launch a Claude Code subprocess.
+Two runtimes are supported, selected by ``ScanConfig.agent_runtime``:
+
+- ``"claude"`` (default) — the Anthropic Claude Code CLI.
+- ``"wksp"`` — the Workshop CLI (https://workshop.ai) which emits the
+  same stream-json shape via ``--output-format claude-stream-json``.
+
+The wksp branch exists so installations without a Claude Code binary
+(or with a wksp-only LLM proxy token) can still run Thresher unmodified.
 """
 
 from __future__ import annotations
@@ -20,6 +25,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
 from contextlib import ExitStack
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -32,6 +38,41 @@ from thresher.run import run as run_cmd
 logger = logging.getLogger(__name__)
 
 _SHARED_HOOK = Path(__file__).parent / "hooks" / "_common" / "validate_json_output.sh"
+
+
+# Claude Code tool names → wksp-accepted aliases. wksp's own
+# ``normalize_tool_names`` then expands ``read``/``grep``/``bash``/etc.
+# into backend tool IDs (``read_file``/``grep_search``/``terminal_run``...).
+# wksp has no native ``Glob`` tool; we route it through ``bash`` so the
+# agent can shell out to ``find``.
+_CLAUDE_TO_WKSP_TOOL: dict[str, str] = {
+    "Read": "read",
+    "Edit": "edit",
+    "Write": "edit",
+    "MultiEdit": "edit",
+    "NotebookEdit": "edit",
+    "Grep": "grep",
+    "Glob": "bash",
+    "Bash": "bash",
+    "BashOutput": "bash",
+    "KillShell": "bash",
+    "WebFetch": "webfetch",
+    "WebSearch": "webfetch",
+    "Task": "task",
+    "Skill": "skill",
+}
+
+
+def _translate_tools(claude_tools: list[str]) -> list[str]:
+    """Map Claude Code tool names to wksp-accepted aliases (deduped)."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for tool in claude_tools:
+        mapped = _CLAUDE_TO_WKSP_TOOL.get(tool, tool)
+        if mapped not in seen:
+            seen.add(mapped)
+            out.append(mapped)
+    return out
 
 
 def build_stop_hook_settings(schema_name: str) -> str:
@@ -64,7 +105,7 @@ def build_stop_hook_settings(schema_name: str) -> str:
 
 @dataclass
 class AgentSpec:
-    """Declarative description of a Claude Code agent invocation."""
+    """Declarative description of a coding-agent invocation."""
 
     label: str
     prompt: str
@@ -89,8 +130,109 @@ class AgentResult:
     model_usage_by_model: dict[str, dict[str, int]] = field(default_factory=dict)
 
 
+def _resolve_wksp_project_dir(spec: AgentSpec, stack: ExitStack) -> str:
+    """Pick a ``--project-dir`` for the wksp subprocess.
+
+    If ``spec.cwd`` is set and is a writable directory, return it — that
+    matches Claude Code's cwd semantics and lets the agent resolve the
+    relative paths its prompt uses (``executive-summary.md``, etc).
+
+    Otherwise allocate a fresh TemporaryDirectory (the agent is expected
+    to use absolute paths — this directory just holds ``memex.log``).
+    """
+    if spec.cwd:
+        cwd_path = Path(spec.cwd)
+        if cwd_path.is_dir() and os.access(cwd_path, os.W_OK):
+            return str(cwd_path)
+    return stack.enter_context(
+        tempfile.TemporaryDirectory(suffix=f"_{spec.label}_proj"),
+    )
+
+
+def _build_claude_cmd(
+    spec: AgentSpec,
+    config: ScanConfig,
+    stack: ExitStack,
+) -> list[str]:
+    """Build argv for the Claude Code CLI. Prompt goes into a tempfile."""
+    prompt_path = stack.enter_context(
+        tempfile_with(spec.prompt, suffix=f"_{spec.label}_prompt.txt"),
+    )
+    cmd: list[str] = [
+        "claude",
+        "-p",
+        str(prompt_path),
+        "--model",
+        config.model,
+        "--allowedTools",
+        ",".join(spec.allowed_tools),
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--max-turns",
+        str(spec.max_turns),
+    ]
+    if spec.hooks_settings_json is not None:
+        settings_path = stack.enter_context(
+            tempfile_with(
+                spec.hooks_settings_json,
+                suffix=f"_{spec.label}_hooks.json",
+            ),
+        )
+        cmd.extend(["--settings", str(settings_path)])
+    return cmd
+
+
+def _build_wksp_cmd(
+    spec: AgentSpec,
+    config: ScanConfig,
+    stack: ExitStack,
+) -> list[str]:
+    """Build argv for the wksp CLI.
+
+    wksp's ``-p`` takes an inline prompt string (not a path), so the
+    prompt goes directly into argv. wksp's file tools (Read/Grep/Glob)
+    resolve *relative* paths against ``--project-dir`` — unlike Claude
+    Code, which resolves them against subprocess ``cwd``.
+
+    To preserve Claude's cwd semantics for agents whose prompts say
+    "files are in your cwd" (report_maker, synthesize), we point
+    ``--project-dir`` at ``spec.cwd`` when it's a writable directory.
+    For read-only cwds (analysts/predep/adversarial scanning
+    ``/opt/source``) we fall back to a writable tempdir; those agents
+    already use absolute paths in their prompts, so the project-dir is
+    only needed for wksp's ``memex.log``. Tool names are translated to
+    wksp's namespace.
+    """
+    project_dir = _resolve_wksp_project_dir(spec, stack)
+    cmd: list[str] = [
+        "wksp",
+        "--project-dir",
+        project_dir,
+        "-p",
+        spec.prompt,
+        "--model",
+        config.model,
+        "--allowed-tools",
+        ",".join(_translate_tools(spec.allowed_tools)),
+        "--output-format",
+        "claude-stream-json",
+        "--max-turns",
+        str(spec.max_turns),
+    ]
+    if spec.hooks_settings_json is not None:
+        settings_path = stack.enter_context(
+            tempfile_with(
+                spec.hooks_settings_json,
+                suffix=f"_{spec.label}_hooks.json",
+            ),
+        )
+        cmd.extend(["--settings", str(settings_path)])
+    return cmd
+
+
 def run_agent(spec: AgentSpec, config: ScanConfig) -> AgentResult:
-    """Launch a Claude Code agent and return its parsed result.
+    """Launch a coding-agent CLI and return its parsed result.
 
     Wraps prompt + settings tempfile management, command assembly, env
     merging, subprocess invocation, and stream-JSON extraction. Any
@@ -104,31 +246,10 @@ def run_agent(spec: AgentSpec, config: ScanConfig) -> AgentResult:
 
     try:
         with ExitStack() as stack:
-            prompt_path = stack.enter_context(
-                tempfile_with(spec.prompt, suffix=f"_{spec.label}_prompt.txt"),
-            )
-            cmd: list[str] = [
-                "claude",
-                "-p",
-                str(prompt_path),
-                "--model",
-                config.model,
-                "--allowedTools",
-                ",".join(spec.allowed_tools),
-                "--output-format",
-                "stream-json",
-                "--verbose",
-                "--max-turns",
-                str(spec.max_turns),
-            ]
-            if spec.hooks_settings_json is not None:
-                settings_path = stack.enter_context(
-                    tempfile_with(
-                        spec.hooks_settings_json,
-                        suffix=f"_{spec.label}_hooks.json",
-                    ),
-                )
-                cmd.extend(["--settings", str(settings_path)])
+            if config.agent_runtime == "wksp":
+                cmd = _build_wksp_cmd(spec, config, stack)
+            else:
+                cmd = _build_claude_cmd(spec, config, stack)
 
             proc = run_cmd(
                 cmd,

--- a/src/thresher/agents/definitions/01-paranoid.yaml
+++ b/src/thresher/agents/definitions/01-paranoid.yaml
@@ -47,6 +47,12 @@ prompt: |
      CSV files, images, fonts, WASM blobs. Look for files whose content
      doesn't match their extension.
 
+  ## Narration during investigation
+
+  After each tool call, state in one sentence what you learned before the next
+  call. This keeps the trace readable and ensures the run still produces text
+  output if the turn budget is exhausted before you reach the final JSON.
+
   ## Output Info
 
   You must output only JSON and in this format with no fences and no comments:

--- a/src/thresher/agents/definitions/02-behaviorist.yaml
+++ b/src/thresher/agents/definitions/02-behaviorist.yaml
@@ -8,7 +8,7 @@ tools:
 - semgrep
 - diff
 - openssl
-max_turns: 30
+max_turns: 120
 prompt: |
   You are The Behaviorist — a security researcher who specializes in finding
   0-days by reading source code. You don't care about known CVEs — those are
@@ -46,6 +46,12 @@ prompt: |
      implementations that use ECB mode or fixed IVs.
 
   6. Others as you see fit.
+
+  ## Narration during investigation
+
+  After each tool call, state in one sentence what you learned before the next
+  call. This keeps the trace readable and ensures the run still produces text
+  output if the turn budget is exhausted before you reach the final JSON.
 
   ## Output Info
 

--- a/src/thresher/agents/definitions/03-investigator.yaml
+++ b/src/thresher/agents/definitions/03-investigator.yaml
@@ -51,6 +51,12 @@ prompt: |
   
   9. Others as you see fit
 
+  ## Narration during investigation
+
+  After each tool call, state in one sentence what you learned before the next
+  call. This keeps the trace readable and ensures the run still produces text
+  output if the turn budget is exhausted before you reach the final JSON.
+
   ## Output Info
 
   You must output only JSON and in this format with no fences and no comments:

--- a/src/thresher/agents/definitions/04-pentester-vulns.yaml
+++ b/src/thresher/agents/definitions/04-pentester-vulns.yaml
@@ -21,6 +21,12 @@ prompt: |
   - Downloaded dependency source code at /opt/deps
   - CLI tools via Bash like: ast-grep, semgrep, jq, python3, git log and others...
 
+  ## Narration during investigation
+
+  After each tool call, state in one sentence what you learned before the next
+  call. This keeps the trace readable and ensures the run still produces text
+  output if the turn budget is exhausted before you reach the final JSON.
+
   ## Output Info
 
   You must output only JSON and in this format with no fences and no comments:

--- a/src/thresher/agents/definitions/05-pentester-appsurface.yaml
+++ b/src/thresher/agents/definitions/05-pentester-appsurface.yaml
@@ -7,7 +7,7 @@ tools:
 - semgrep
 - jq
 - openssl
-max_turns: 30
+max_turns: 120
 prompt: |
   You are a web application pentester who specializes in API security, auth
   bypasses, and OWASP Top 10. You evaluate the code as if it's about to be
@@ -48,6 +48,12 @@ prompt: |
   6. **Admin/debug endpoints**: Routes that shouldn't be exposed in production.
 
   7. Other areas as you see fit
+
+  ## Narration during investigation
+
+  After each tool call, state in one sentence what you learned before the next
+  call. This keeps the trace readable and ensures the run still produces text
+  output if the turn budget is exhausted before you reach the final JSON.
 
   ## Output Info
 

--- a/src/thresher/agents/definitions/06-pentester-memory.yaml
+++ b/src/thresher/agents/definitions/06-pentester-memory.yaml
@@ -11,7 +11,7 @@ tools:
 - strings
 - ldd
 - size
-max_turns: 30
+max_turns: 120
 prompt: |
   You are a low-level exploit developer who thinks in terms of memory layouts,
   type confusion, and runtime guarantees. You focus on native code, C extensions,
@@ -54,6 +54,12 @@ prompt: |
      Use `ast-grep` to find regex compilation and match patterns.
 
   9. Other areas you think of.
+
+  ## Narration during investigation
+
+  After each tool call, state in one sentence what you learned before the next
+  call. This keeps the trace readable and ensures the run still produces text
+  output if the turn budget is exhausted before you reach the final JSON.
 
   ## Output Info
 

--- a/src/thresher/agents/definitions/07-infra-auditor.yaml
+++ b/src/thresher/agents/definitions/07-infra-auditor.yaml
@@ -51,6 +51,12 @@ prompt: |
 
   9. Other things as you see fit.
 
+  ## Narration during investigation
+
+  After each tool call, state in one sentence what you learned before the next
+  call. This keeps the trace readable and ensures the run still produces text
+  output if the turn budget is exhausted before you reach the final JSON.
+
   ## Output Info
 
   You must output only JSON and in this format with no fences and no comments:

--- a/src/thresher/agents/definitions/08-shadowcatcher.yaml
+++ b/src/thresher/agents/definitions/08-shadowcatcher.yaml
@@ -13,7 +13,7 @@ tools:
 - git fsck
 - python3
 - file
-max_turns: 40
+max_turns: 120
 prompt: |
   You are The Shadowcatcher — a malware reverse engineer who specializes in
   evasion techniques, steganography, and code that's designed to not look
@@ -62,6 +62,12 @@ prompt: |
      extensions. Files whose names are designed to blend in.
 
   9. Other things that you think of.
+
+  ## Narration during investigation
+
+  After each tool call, state in one sentence what you learned before the next
+  call. This keeps the trace readable and ensures the run still produces text
+  output if the turn budget is exhausted before you reach the final JSON.
 
   ## Output Info
 

--- a/src/thresher/agents/runtime.py
+++ b/src/thresher/agents/runtime.py
@@ -1,0 +1,38 @@
+"""Pluggable agent-runtime registry.
+
+Each runtime (``claude``, ``wksp``, …) may need host files forwarded into
+the harness container so the in-container CLI can authenticate. This
+module is the single place that knows which files belong to which
+runtime; launchers iterate the returned mounts without caring about
+their semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class HostFileMount:
+    """A host file that must be readable inside the harness container."""
+
+    host_path: Path
+    container_path: str
+
+
+def runtime_host_mounts(agent_runtime: str) -> list[HostFileMount]:
+    """Files on the host that the given runtime needs inside the container.
+
+    Launchers should skip any mount whose ``host_path`` does not exist —
+    the host may simply not have that runtime configured, in which case
+    the runtime is expected to fall back to env-based credentials.
+    """
+    if agent_runtime == "wksp":
+        return [
+            HostFileMount(
+                host_path=Path.home() / ".config" / "workshop" / "credentials.json",
+                container_path="/home/thresher/.config/workshop/credentials.json",
+            ),
+        ]
+    return []

--- a/src/thresher/config.py
+++ b/src/thresher/config.py
@@ -99,6 +99,7 @@ class ScanConfig:
     report_maker_max_turns: int | None = None  # Override report-maker agent max_turns (default 15)
     synthesize_max_turns: int | None = None  # Override synthesize agent max_turns (default 75)
     launch_mode: str = "lima"  # How the harness is launched: lima, docker, or direct
+    agent_runtime: str = "claude"  # Which CLI drives agents: claude or wksp
 
     @property
     def has_ai_credentials(self) -> bool:
@@ -121,7 +122,7 @@ class ScanConfig:
         errors = []
         if not self.repo_url and not self.local_path:
             errors.append("repo_url or local_path is required")
-        if not self.skip_ai and not self.has_ai_credentials:
+        if not self.skip_ai and self.agent_runtime != "wksp" and not self.has_ai_credentials:
             errors.append(
                 "No AI credentials found. Set ANTHROPIC_API_KEY, log in with `claude login`, or use --skip-ai"
             )
@@ -129,6 +130,8 @@ class ScanConfig:
             errors.append("depth must be >= 1")
         if self.launch_mode not in ("lima", "docker", "direct"):
             errors.append(f"launch_mode must be one of 'lima', 'docker', 'direct'; got {self.launch_mode!r}")
+        if self.agent_runtime not in ("claude", "wksp"):
+            errors.append(f"agent_runtime must be one of 'claude', 'wksp'; got {self.agent_runtime!r}")
         return errors
 
     def to_json(self) -> str:
@@ -152,6 +155,7 @@ class ScanConfig:
             "synthesize_max_turns": self.synthesize_max_turns,
             "local_path": self.local_path,
             "launch_mode": self.launch_mode,
+            "agent_runtime": self.agent_runtime,
             "vm": {
                 "cpus": self.vm.cpus,
                 "memory": self.vm.memory,
@@ -197,6 +201,7 @@ class ScanConfig:
             "synthesize_max_turns",
             "local_path",
             "launch_mode",
+            "agent_runtime",
         }
         filtered = {k: v for k, v in data.items() if k in known_fields}
         return cls(vm=vm, limits=limits, **filtered)
@@ -234,6 +239,8 @@ def load_config(
             config.log_dir = data["log_dir"]
         if "tmux" in data:
             config.tmux = data["tmux"]
+        if "agent_runtime" in data:
+            config.agent_runtime = data["agent_runtime"]
         vm_data = data.get("vm", {})
         if "cpus" in vm_data:
             config.vm.cpus = vm_data["cpus"]

--- a/src/thresher/launcher/docker.py
+++ b/src/thresher/launcher/docker.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from thresher.agents.runtime import runtime_host_mounts
 from thresher.config import ScanConfig
 from thresher.fs import tempfile_with
 from thresher.launcher._container import build_docker_args
@@ -22,6 +23,7 @@ def launch_docker(config: ScanConfig) -> int:
     config_for_container = config
     if config.local_path:
         import copy
+
         config_for_container = copy.copy(config)
         config_for_container.local_path = "/opt/source"
 
@@ -57,11 +59,19 @@ def _resolve_log_file(config: ScanConfig) -> str | None:
 
 def _build_docker_cmd(config: ScanConfig, config_path: str, output_dir: str) -> list[str]:
     env_flags: list[str] = []
+    extra_mounts: list[str] = []
     # Pass credentials explicitly — they may come from Keychain, not env vars
     if config.anthropic_api_key:
         env_flags += ["-e", f"ANTHROPIC_API_KEY={config.anthropic_api_key}"]
     elif config.oauth_token:
         env_flags += ["-e", f"CLAUDE_CODE_OAUTH_TOKEN={config.oauth_token}"]
+
+    # Forward host files the configured agent runtime needs (e.g. wksp's
+    # ~/.config/workshop/credentials.json). Missing files are skipped so
+    # the runtime can fall back to env-based credentials.
+    for mount in runtime_host_mounts(config.agent_runtime):
+        if mount.host_path.exists():
+            extra_mounts += ["-v", f"{mount.host_path}:{mount.container_path}:ro"]
 
     source_mount = None
     if config.local_path:
@@ -70,6 +80,6 @@ def _build_docker_cmd(config: ScanConfig, config_path: str, output_dir: str) -> 
     return build_docker_args(
         output_mount=f"{output_dir}:/output",
         config_mount=f"{config_path}:/config/config.json:ro",
-        env_flags=env_flags,
+        env_flags=env_flags + extra_mounts,
         source_mount=source_mount,
     )

--- a/src/thresher/launcher/lima.py
+++ b/src/thresher/launcher/lima.py
@@ -1,15 +1,25 @@
 """Lima+Docker launch mode — maximum isolation."""
 
+import hashlib
 import logging
+import os
 import subprocess
 from pathlib import Path
 
+from thresher.agents.runtime import HostFileMount, runtime_host_mounts
 from thresher.config import ScanConfig
 from thresher.fs import tempfile_with
 from thresher.launcher._container import build_docker_args
 
 logger = logging.getLogger(__name__)
 BASE_VM_NAME = "thresher-base"
+
+
+def _vm_staging_path(mount: HostFileMount) -> str:
+    """Per-mount staging path inside the VM. The hash keeps separate
+    runtimes from clobbering each other's files in /opt."""
+    digest = hashlib.sha1(mount.container_path.encode()).hexdigest()[:12]
+    return f"/opt/runtime-{digest}-{mount.host_path.name}"
 
 
 def launch_lima(config: ScanConfig) -> int:
@@ -21,6 +31,7 @@ def launch_lima(config: ScanConfig) -> int:
     config_for_container = config
     if config.local_path:
         import copy
+
         config_for_container = copy.copy(config)
         config_for_container.local_path = "/opt/source"
 
@@ -34,6 +45,18 @@ def launch_lima(config: ScanConfig) -> int:
                 ["limactl", "copy", "-r", config.local_path, f"{BASE_VM_NAME}:/opt/source"],
                 check=True,
             )
+        # Stage runtime credentials inside the VM so docker can mount them
+        # into the harness container. Missing host files are skipped.
+        for mount in runtime_host_mounts(config.agent_runtime):
+            if mount.host_path.exists():
+                subprocess.run(
+                    ["limactl", "copy", str(mount.host_path), f"{BASE_VM_NAME}:{_vm_staging_path(mount)}"],
+                    check=True,
+                )
+        subprocess.run(
+            ["limactl", "shell", BASE_VM_NAME, "--", "sudo", "chmod", "-R", "a+rX", "/opt"],
+            check=True,
+        )
         docker_cmd = _build_lima_docker_cmd(config)
         result = subprocess.run(["limactl", "shell", BASE_VM_NAME, "--", *docker_cmd])
         if result.returncode == 0:
@@ -72,18 +95,33 @@ def _build_lima_docker_cmd(config: ScanConfig) -> list[str]:
     if config.local_path:
         source_mount = "/opt/source:/opt/source:ro"
 
+    extra_flags = _build_credential_env_flags()
+    for mount in runtime_host_mounts(config.agent_runtime):
+        if not mount.host_path.exists():
+            continue
+        # Inside the VM, docker mounts the staged copy — not the host path.
+        extra_flags += ["-v", f"{_vm_staging_path(mount)}:{mount.container_path}:ro"]
+
     return build_docker_args(
         output_mount="/opt/reports:/output",
         config_mount="/opt/config.json:/config/config.json:ro",
-        # Forward host env vars by name through limactl shell.
-        env_flags=[
-            "-e",
-            "ANTHROPIC_API_KEY",
-            "-e",
-            "CLAUDE_CODE_OAUTH_TOKEN",
-        ],
+        # Forward host env vars by VALUE. `limactl shell --` runs a
+        # non-login, non-interactive shell that does NOT source
+        # /etc/environment or /etc/profile, so by-name forwarding
+        # (`-e KEY`) gets empty strings inside the VM. Pass values
+        # explicitly so docker sees them.
+        env_flags=extra_flags,
         source_mount=source_mount,
     )
+
+
+def _build_credential_env_flags() -> list[str]:
+    flags: list[str] = []
+    for key in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"):
+        value = os.environ.get(key)
+        if value:
+            flags += ["-e", f"{key}={value}"]
+    return flags
 
 
 def _copy_report_to_host(output_dir: str) -> None:

--- a/tests/unit/test_agents_runner.py
+++ b/tests/unit/test_agents_runner.py
@@ -5,15 +5,21 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
-from thresher.agents._runner import AgentResult, AgentSpec, run_agent
+from thresher.agents._runner import (
+    AgentResult,
+    AgentSpec,
+    _translate_tools,
+    run_agent,
+)
 from thresher.config import ScanConfig
 
 
-def _make_config() -> ScanConfig:
+def _make_config(agent_runtime: str = "claude") -> ScanConfig:
     return ScanConfig(
         repo_url="https://github.com/x/y",
         anthropic_api_key="sk-ant-test-key",
         model="sonnet",
+        agent_runtime=agent_runtime,
     )
 
 
@@ -141,3 +147,116 @@ class TestRunAgent:
         result = run_agent(self._spec(), _make_config())
         assert result.result_text == ""
         assert result.num_turns == 0
+
+
+class TestWkspRuntime:
+    def _spec(self, **overrides):
+        defaults = dict(
+            label="test-agent",
+            prompt="say hi",
+            allowed_tools=["Read", "Grep", "Glob"],
+            max_turns=10,
+            timeout=60,
+            cwd="/tmp",
+        )
+        defaults.update(overrides)
+        return AgentSpec(**defaults)
+
+    @patch("thresher.run._popen")
+    def test_invokes_wksp_binary(self, mock):
+        mock.return_value = _mock_popen(stdout=_stream_json())
+        run_agent(self._spec(), _make_config(agent_runtime="wksp"))
+        cmd = mock.call_args[0][0]
+        assert cmd[0] == "wksp"
+
+    @patch("thresher.run._popen")
+    def test_prompt_passed_inline_not_as_path(self, mock):
+        mock.return_value = _mock_popen(stdout=_stream_json())
+        run_agent(
+            self._spec(prompt="hello world"),
+            _make_config(agent_runtime="wksp"),
+        )
+        cmd = mock.call_args[0][0]
+        # wksp's -p takes the prompt string directly, not a tempfile path.
+        assert cmd[cmd.index("-p") + 1] == "hello world"
+
+    @patch("thresher.run._popen")
+    def test_uses_claude_stream_json_output_format(self, mock):
+        mock.return_value = _mock_popen(stdout=_stream_json())
+        run_agent(self._spec(), _make_config(agent_runtime="wksp"))
+        cmd = mock.call_args[0][0]
+        assert cmd[cmd.index("--output-format") + 1] == "claude-stream-json"
+        # wksp uses --allowed-tools (kebab-case), not --allowedTools.
+        assert "--allowed-tools" in cmd
+        assert "--allowedTools" not in cmd
+        # wksp has no --verbose flag.
+        assert "--verbose" not in cmd
+
+    @patch("thresher.run._popen")
+    def test_translates_tool_names(self, mock):
+        mock.return_value = _mock_popen(stdout=_stream_json())
+        run_agent(
+            self._spec(allowed_tools=["Read", "Grep", "Glob", "Bash"]),
+            _make_config(agent_runtime="wksp"),
+        )
+        cmd = mock.call_args[0][0]
+        tools = cmd[cmd.index("--allowed-tools") + 1]
+        # Glob → bash collides with Bash → bash; must be deduped.
+        assert tools == "read,grep,bash"
+
+    @patch("thresher.run._popen")
+    def test_project_dir_is_writable_temp(self, mock):
+        mock.return_value = _mock_popen(stdout=_stream_json())
+        # spec.cwd="/tmp" is writable, so project-dir becomes /tmp itself
+        # (matching Claude's cwd semantics for relative-path reads).
+        run_agent(self._spec(cwd="/tmp"), _make_config(agent_runtime="wksp"))
+        cmd = mock.call_args[0][0]
+        project_dir = cmd[cmd.index("--project-dir") + 1]
+        assert project_dir == "/tmp"
+
+    @patch("thresher.run._popen")
+    def test_project_dir_falls_back_to_tempdir_when_cwd_not_writable(
+        self, mock, tmp_path
+    ):
+        mock.return_value = _mock_popen(stdout=_stream_json())
+        ro_dir = tmp_path / "readonly"
+        ro_dir.mkdir()
+        ro_dir.chmod(0o555)
+        try:
+            run_agent(
+                self._spec(cwd=str(ro_dir)),
+                _make_config(agent_runtime="wksp"),
+            )
+        finally:
+            ro_dir.chmod(0o755)
+        cmd = mock.call_args[0][0]
+        project_dir = cmd[cmd.index("--project-dir") + 1]
+        # Fresh tempdir, not the read-only cwd.
+        assert project_dir != str(ro_dir)
+        assert project_dir.endswith("_test-agent_proj")
+
+    @patch("thresher.run._popen")
+    def test_project_dir_falls_back_to_tempdir_when_cwd_missing(self, mock):
+        mock.return_value = _mock_popen(stdout=_stream_json())
+        run_agent(self._spec(cwd=None), _make_config(agent_runtime="wksp"))
+        cmd = mock.call_args[0][0]
+        project_dir = cmd[cmd.index("--project-dir") + 1]
+        assert project_dir.endswith("_test-agent_proj")
+
+
+def test_translate_tools_maps_claude_to_wksp():
+    assert _translate_tools(["Read", "Grep", "Edit"]) == ["read", "grep", "edit"]
+
+
+def test_translate_tools_routes_glob_through_bash():
+    # wksp has no native Glob; the agent shells out to `find` instead.
+    assert _translate_tools(["Glob"]) == ["bash"]
+
+
+def test_translate_tools_dedupes_collisions():
+    # Glob → bash and Bash → bash collide; both mappings produce one entry.
+    assert _translate_tools(["Glob", "Bash"]) == ["bash"]
+
+
+def test_translate_tools_passthrough_unknown_names():
+    assert _translate_tools(["CustomTool"]) == ["CustomTool"]

--- a/tests/unit/test_agents_runtime.py
+++ b/tests/unit/test_agents_runtime.py
@@ -1,0 +1,23 @@
+"""Tests for the pluggable agent-runtime registry."""
+
+from __future__ import annotations
+
+from thresher.agents.runtime import HostFileMount, runtime_host_mounts
+
+
+def test_claude_runtime_has_no_host_mounts():
+    assert runtime_host_mounts("claude") == []
+
+
+def test_unknown_runtime_has_no_host_mounts():
+    assert runtime_host_mounts("does-not-exist") == []
+
+
+def test_wksp_runtime_forwards_credentials_file():
+    mounts = runtime_host_mounts("wksp")
+    assert len(mounts) == 1
+    mount = mounts[0]
+    assert isinstance(mount, HostFileMount)
+    assert mount.host_path.name == "credentials.json"
+    assert mount.host_path.parent.name == "workshop"
+    assert mount.container_path == "/home/thresher/.config/workshop/credentials.json"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -494,3 +494,33 @@ class TestLaunchMode:
         assert config.launch_mode == "direct"
         assert config.skip_ai is True
         assert config.model == "opus"
+
+
+class TestAgentRuntime:
+    def test_scan_config_agent_runtime_default(self):
+        """agent_runtime defaults to 'claude' for backwards compatibility."""
+        config = ScanConfig()
+        assert config.agent_runtime == "claude"
+
+    def test_scan_config_agent_runtime_from_dict(self):
+        """agent_runtime can be set to 'wksp'."""
+        config = ScanConfig(agent_runtime="wksp")
+        assert config.agent_runtime == "wksp"
+
+    def test_scan_config_agent_runtime_validates(self):
+        """agent_runtime rejects values other than 'claude' or 'wksp'."""
+        config = ScanConfig(
+            repo_url="https://example.com/r",
+            skip_ai=True,
+            agent_runtime="bogus",
+        )
+        errors = config.validate()
+        assert any("agent_runtime" in e for e in errors)
+
+    def test_scan_config_roundtrips_through_json(self):
+        config = ScanConfig(
+            repo_url="https://github.com/test/repo",
+            agent_runtime="wksp",
+        )
+        restored = ScanConfig.from_json(config.to_json())
+        assert restored.agent_runtime == "wksp"

--- a/tests/unit/test_launcher_docker.py
+++ b/tests/unit/test_launcher_docker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -151,6 +152,47 @@ class TestBuildDockerCmd:
         idx = cmd.index("--output")
         assert cmd[idx + 1] == "/output"
 
+    def test_wksp_runtime_mounts_credentials(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "home"
+        creds = fake_home / ".config" / "workshop" / "credentials.json"
+        creds.parent.mkdir(parents=True)
+        creds.write_text("{}")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        config = ScanConfig(
+            repo_url="https://github.com/example/pkg",
+            output_dir="/tmp/test-output",
+            skip_ai=True,
+            agent_runtime="wksp",
+        )
+        cmd = _build_docker_cmd(config, "/tmp/config.json", config.output_dir)
+        v_indices = [i for i, v in enumerate(cmd) if v == "-v"]
+        vol_args = [cmd[i + 1] for i in v_indices]
+        assert any(v == f"{creds}:/home/thresher/.config/workshop/credentials.json:ro" for v in vol_args)
+
+    def test_wksp_runtime_skips_mount_when_creds_missing(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        config = ScanConfig(
+            repo_url="https://github.com/example/pkg",
+            output_dir="/tmp/test-output",
+            skip_ai=True,
+            agent_runtime="wksp",
+        )
+        cmd = _build_docker_cmd(config, "/tmp/config.json", config.output_dir)
+        v_indices = [i for i, v in enumerate(cmd) if v == "-v"]
+        vol_args = [cmd[i + 1] for i in v_indices]
+        assert not any("workshop/credentials.json" in v for v in vol_args)
+
+    def test_claude_runtime_omits_wksp_mount(self):
+        config = _make_config()
+        cmd = _build_docker_cmd(config, "/tmp/config.json", config.output_dir)
+        v_indices = [i for i, v in enumerate(cmd) if v == "-v"]
+        vol_args = [cmd[i + 1] for i in v_indices]
+        assert not any("workshop/credentials.json" in v for v in vol_args)
+
 
 class TestLocalPathMount:
     def test_docker_cmd_mounts_local_path(self, tmp_path):
@@ -183,6 +225,7 @@ class TestLocalPathMount:
         written_json = []
 
         with patch("thresher.launcher.docker.tempfile_with") as mock_tf:
+
             @contextmanager
             def capture(content, **kwargs):
                 written_json.append(content)

--- a/tests/unit/test_launcher_lima.py
+++ b/tests/unit/test_launcher_lima.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -128,19 +129,64 @@ class TestBuildLimaDockerCmd:
         idx = cmd.index("--user")
         assert cmd[idx + 1] == "thresher"
 
-    def test_includes_anthropic_api_key_env(self):
+    def test_includes_anthropic_api_key_env(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         config = _make_config()
         cmd = _build_lima_docker_cmd(config)
         e_indices = [i for i, v in enumerate(cmd) if v == "-e"]
         env_vars = [cmd[i + 1] for i in e_indices]
-        assert "ANTHROPIC_API_KEY" in env_vars
+        assert "ANTHROPIC_API_KEY=sk-test-key" in env_vars
 
-    def test_includes_oauth_token_env(self):
+    def test_includes_oauth_token_env(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-test-token")
         config = _make_config()
         cmd = _build_lima_docker_cmd(config)
         e_indices = [i for i, v in enumerate(cmd) if v == "-e"]
         env_vars = [cmd[i + 1] for i in e_indices]
-        assert "CLAUDE_CODE_OAUTH_TOKEN" in env_vars
+        assert "CLAUDE_CODE_OAUTH_TOKEN=oauth-test-token" in env_vars
+
+    def test_omits_credentials_when_unset(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        config = _make_config()
+        cmd = _build_lima_docker_cmd(config)
+        e_indices = [i for i, v in enumerate(cmd) if v == "-e"]
+        env_vars = [cmd[i + 1] for i in e_indices]
+        assert not any(v.startswith("ANTHROPIC_API_KEY") for v in env_vars)
+        assert not any(v.startswith("CLAUDE_CODE_OAUTH_TOKEN") for v in env_vars)
+
+    def test_wksp_runtime_mounts_credentials(self, tmp_path, monkeypatch):
+        # Pretend the host has a wksp credentials file so the lima docker cmd
+        # emits the mount flag for it.
+        fake_home = tmp_path / "home"
+        creds = fake_home / ".config" / "workshop" / "credentials.json"
+        creds.parent.mkdir(parents=True)
+        creds.write_text("{}")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        config = ScanConfig(
+            repo_url="https://github.com/example/pkg",
+            output_dir="/tmp/test-output",
+            skip_ai=True,
+            agent_runtime="wksp",
+        )
+        cmd = _build_lima_docker_cmd(config)
+        v_indices = [i for i, a in enumerate(cmd) if a == "-v"]
+        vol_args = [cmd[i + 1] for i in v_indices]
+        # The container target is fixed; the staging source path is opaque.
+        assert any(
+            v.endswith(":/home/thresher/.config/workshop/credentials.json:ro") and v.startswith("/opt/runtime-")
+            for v in vol_args
+        )
+
+    def test_claude_runtime_omits_wksp_mount(self):
+        config = _make_config()
+        cmd = _build_lima_docker_cmd(config)
+        v_indices = [i for i, a in enumerate(cmd) if a == "-v"]
+        vol_args = [cmd[i + 1] for i in v_indices]
+        assert not any("workshop/credentials.json" in v for v in vol_args)
 
     def test_includes_tmpfs_mounts(self):
         config = _make_config()


### PR DESCRIPTION
# Pluggable agent runtime: support wksp alongside Claude Code

## Summary

Thresher's agents currently assume the Claude Code CLI is the only way
to drive an LLM in headless mode. This PR makes the agent CLI
pluggable so installations without Claude Code (or with a different
LLM proxy / login model) can run Thresher unmodified.

A new `agent_runtime: "claude" | "wksp"` field on `ScanConfig` selects
the CLI. Today only `claude` (default) and `wksp` (Workshop CLI,
https://workshop.ai) are wired in, but the seams are sized for adding
more later — codex, gemini, etc.

The wksp branch was added because wksp emits Claude-compatible
stream-json (`--output-format claude-stream-json`), so result
extraction is unchanged; only the argv shape, tool naming, and
credential storage differ.

## Changes

Three commits, each independently reviewable:

### 1. `config: add agent_runtime field`

- New `agent_runtime: str = "claude"` on `ScanConfig`, validated to
  `{"claude", "wksp"}`.
- Round-trips through `to_json` / `from_json` and the TOML loader.
- Credential validation skips the Anthropic key/token requirement
  when `agent_runtime == "wksp"` (wksp authenticates via a host file,
  not env vars).

### 2. `runner: support wksp CLI as alternate agent runtime`

- Factors the existing Claude argv build out of the shared agent
  runner; adds a parallel wksp branch.
- Maps Claude tool names to wksp's accepted aliases
  (`Read→read`, `Bash→bash`, `Grep→grep`, …). `Glob` routes through
  `bash` since wksp has no native Glob tool.
- When `agent_runtime=wksp`, uses the spec's cwd as `--project-dir`
  if it is writable, else a fresh `TemporaryDirectory`, so relative
  paths resolve consistently regardless of where the harness is
  invoked from.

### 3. `launcher: forward runtime credentials via pluggable registry`

- New `thresher.agents.runtime` registry: a tiny module that knows
  which host files each runtime needs forwarded into the harness
  container.
- Today only wksp declares a mount
  (`~/.config/workshop/credentials.json` →
  `/home/thresher/.config/workshop/credentials.json`). Adding a new
  runtime is one entry in `runtime_host_mounts(name)` — not a touch
  on every launcher.
- The docker launcher iterates the registry and emits `-v` flags
  directly.
- The lima launcher additionally stages each file inside the VM via
  `limactl copy` (since docker runs inside the VM and cannot mount
  host paths) before mounting it into the container. Staging paths
  use a hash of the container path so multiple runtimes don't collide
  in `/opt`.
- Lima also gains by-VALUE credential forwarding for
  `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`. `limactl shell --`
  runs a non-login, non-interactive shell that does not source
  `/etc/environment`, so the previous `-e KEY` by-name forwarding
  silently passed empty strings into the VM. Tests are updated to use
  `monkeypatch.setenv` and assert on the `KEY=value` form.

## Design notes

- The runtime registry only models *host file forwarding* today —
  Claude's env-based credential plumbing stays in the launchers since
  it's tightly coupled to existing `ScanConfig` fields. If we add a
  third runtime that also wants env injection, we can promote that
  into the registry too.
- Hash-prefixed staging paths in lima (`/opt/runtime-<sha>-<name>`)
  prevent two runtimes that happen to declare files with the same
  basename from clobbering each other inside the VM.
- Missing host files are silently skipped at both the
  copy-into-VM step and the docker mount step. A runtime that isn't
  configured on the host falls through to env-based credentials.

## Testing

- `uv run pytest tests/unit/test_config.py
  tests/unit/test_agents_runner.py tests/unit/test_agents_runtime.py
  tests/unit/test_launcher_docker.py tests/unit/test_launcher_lima.py`
  — 143 passed.
- New coverage: agent_runtime config validation/serialization, wksp
  argv / tool-name translation / project-dir fallback, runtime
  registry contents, docker + lima credential mount emission with
  monkeypatched `Path.home()` for filesystem isolation.
- Pre-existing failures in `tests/unit/test_analysts.py` are
  unrelated (also fail on `main`).
- Exercised end-to-end against a representative target with the wksp
  runtime: harness boots, all 12 agent invocations complete, no
  Anthropic credentials touched.

## Compatibility

- Default behavior unchanged: `agent_runtime` defaults to `"claude"`.
- No breaking changes to existing config, launcher, or runner APIs.
- TOML config files without `agent_runtime` continue to work.
